### PR TITLE
configure changed retool dir once in ./hack/retool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ default.pd
 *.swp
 .DS_Store
 tags
-/_retools/
+/.retools/

--- a/hack/retool
+++ b/hack/retool
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Add standard retool options
+set -euo pipefail
+
+
+cd $(dirname "$0")/..
+exec retool -tool-dir "$PWD/.retools" "$@"

--- a/hack/retool-install.sh
+++ b/hack/retool-install.sh
@@ -3,21 +3,23 @@ set -euo pipefail
 
 # This script generates tools.json
 # It helps record what releases/branches are being used
+
+cd $(dirname "$0")/..
 which retool >/dev/null || go get github.com/twitchtv/retool
 
 # tool environment
 # check runner
-retool add gopkg.in/alecthomas/gometalinter.v2 v2.0.5
+./hack/retool add gopkg.in/alecthomas/gometalinter.v2 v2.0.5
 # check spelling
-retool add github.com/client9/misspell/cmd/misspell v0.3.4
+./hack/retool add github.com/client9/misspell/cmd/misspell v0.3.4
 # checks correctness
-retool add github.com/gordonklaus/ineffassign 7bae11eba15a3285c75e388f77eb6357a2d73ee2
-retool add honnef.co/go/tools/cmd/megacheck master
-retool add github.com/dnephin/govet 4a96d43e39d340b63daa8bc5576985aa599885f6
+./hack/retool add github.com/gordonklaus/ineffassign 7bae11eba15a3285c75e388f77eb6357a2d73ee2
+./hack/retool add honnef.co/go/tools/cmd/megacheck master
+./hack/retool add github.com/dnephin/govet 4a96d43e39d340b63daa8bc5576985aa599885f6
 # slow checks
-retool add github.com/kisielk/errcheck v1.1.0
+./hack/retool add github.com/kisielk/errcheck v1.1.0
 # linter
-retool add github.com/mgechev/revive 7773f47324c2bf1c8f7a5500aff2b6c01d3ed73b
-retool add github.com/securego/gosec/cmd/gosec 1.0.0
+./hack/retool add github.com/mgechev/revive 7773f47324c2bf1c8f7a5500aff2b6c01d3ed73b
+./hack/retool add github.com/securego/gosec/cmd/gosec 1.0.0
 # go fail
-retool add github.com/etcd-io/gofail master
+./hack/retool add github.com/etcd-io/gofail master


### PR DESCRIPTION
Change retool dir to .retools

Putting the config in `./hack/retool` makes it easier to use retool outside of the Makefile.